### PR TITLE
set log level to trace when skipping rules

### DIFF
--- a/easylist.go
+++ b/easylist.go
@@ -78,7 +78,7 @@ func Open(cacheFile string, checkInterval time.Duration) (List, error) {
 				rule.Opts.Other != nil ||
 				rule.Opts.SubDocument != nil ||
 				rule.Opts.XmlHttpRequest != nil {
-				log.Debugf("Skipping rule with unsupported option: %v", rule.Raw)
+				log.Tracef("Skipping rule with unsupported option: %v", rule.Raw)
 				skippedRules++
 			} else {
 				err = matcher.AddRule(rule, 0)


### PR DESCRIPTION
When testing or running Lantern, important debug message may be lost in thousands of easylist logs. Changing to `Tracef` makes it less noise but still be able to inspect when required.